### PR TITLE
add API endpoint for newsletter subscription

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,7 @@ import grantRoutes from "./routes/grant.route";
 import grantApplicationRoutes from "./routes/grant-application.route";
 import milestoneRoutes from "./routes/milestone.route";
 import waitlistRoutes from "./routes/waitlist.route";
+import newsletterRoutes from "./routes/newsletter.route";
 
 dotenv.config();
 
@@ -117,6 +118,7 @@ app.use("/api/grants", grantRoutes);
 app.use("/api/grant-applications", grantApplicationRoutes);
 app.use("/api/milestones", milestoneRoutes);
 app.use("/api/waitlist", waitlistRoutes);
+app.use("/api/newsletter", newsletterRoutes);
 
 // Swagger Docs
 setupSwagger(app);

--- a/src/controllers/newsletter.controller.ts
+++ b/src/controllers/newsletter.controller.ts
@@ -1,0 +1,66 @@
+import { Request, Response } from "express";
+import { body, validationResult } from "express-validator";
+import NewsletterService from "../services/newsletter.service";
+import { sendCreated, sendBadRequest, sendError } from "../utils/apiResponse";
+
+/**
+ * @route   POST /api/newsletter/subscribe
+ * @desc    Subscribe to newsletter
+ * @access  Public
+ */
+export const subscribe = async (req: Request, res: Response): Promise<void> => {
+  try {
+    // Validation errors
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      sendBadRequest(
+        res,
+        "Validation failed",
+        errors
+          .array()
+          .map((e) => e.msg)
+          .join(", "),
+      );
+      return;
+    }
+
+    const { email, source } = req.body;
+
+    const subscriber = await NewsletterService.subscribe({
+      email,
+      source,
+      metadata: {
+        ipAddress: req.ip || req.connection?.remoteAddress,
+        userAgent: req.headers["user-agent"],
+      },
+    });
+
+    sendCreated(res, {
+      message: "Successfully subscribed to newsletter",
+      subscriber: {
+        id: subscriber._id,
+        email: subscriber.email,
+        source: subscriber.source,
+      },
+    });
+  } catch (error: any) {
+    if (error.message === "Email already subscribed") {
+      sendError(res, "Email already subscribed", 409);
+      return;
+    }
+
+    sendError(res, "Error subscribing to newsletter", 500, error.message);
+  }
+};
+
+// Validation middleware
+export const validateSubscribe = [
+  body("email").isEmail().normalizeEmail().withMessage("Valid email required"),
+  body("source")
+    .optional()
+    .isString()
+    .isLength({ max: 100 })
+    .withMessage("Source must be <= 100 chars"),
+];
+
+export default { subscribe, validateSubscribe };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,6 +1,7 @@
 import "./badge.model";
 import "./user.model";
 import "./project.model";
+import "./newsletter.model";
 import "./notification.model";
 import "./transaction.model";
 import "./comment.model";

--- a/src/models/newsletter.model.ts
+++ b/src/models/newsletter.model.ts
@@ -1,0 +1,43 @@
+import { Schema, model, Document } from "mongoose";
+
+export interface INewsletterSubscriber extends Document {
+  email: string;
+  source?: string;
+  subscribedAt: Date;
+  metadata?: {
+    ipAddress?: string;
+    userAgent?: string;
+  };
+}
+
+const newsletterSchema = new Schema<INewsletterSubscriber>(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    source: {
+      type: String,
+      maxlength: 100,
+    },
+    subscribedAt: {
+      type: Date,
+      default: Date.now,
+    },
+    metadata: {
+      ipAddress: { type: String },
+      userAgent: { type: String },
+    },
+  },
+  { timestamps: true },
+);
+
+const NewsletterSubscriber = model<INewsletterSubscriber>(
+  "NewsletterSubscriber",
+  newsletterSchema,
+);
+
+export default NewsletterSubscriber;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,7 @@ import grantRoutes from "./grant.route";
 import grantApplicationRoutes from "./grant-application.route";
 import projectVotingRoutes from "./project-voting.route";
 import milestoneRoutes from "./milestone.route";
+import newsletterRoutes from "./newsletter.route";
 
 const router = express.Router();
 
@@ -10,5 +11,5 @@ router.use("/api", grantRoutes);
 router.use("/api", grantApplicationRoutes);
 router.use("/api", projectVotingRoutes);
 router.use("/api/milestones", milestoneRoutes);
-
+router.use("/newsletter", newsletterRoutes);
 export default router;

--- a/src/routes/newsletter.route.ts
+++ b/src/routes/newsletter.route.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import {
+  subscribe,
+  validateSubscribe,
+} from "../controllers/newsletter.controller";
+import { validateRequest } from "../middleware/validateRequest";
+
+const router = Router();
+
+router.post("/subscribe", validateRequest(validateSubscribe), subscribe);
+
+export default router;

--- a/src/services/newsletter.service.ts
+++ b/src/services/newsletter.service.ts
@@ -1,0 +1,24 @@
+import NewsletterSubscriber from "../models/newsletter.model";
+
+export interface CreateNewsletterData {
+  email: string;
+  source?: string;
+  metadata?: {
+    ipAddress?: string;
+    userAgent?: string;
+  };
+}
+
+class NewsletterService {
+  static async subscribe(data: CreateNewsletterData) {
+    const existing = await NewsletterSubscriber.findOne({ email: data.email });
+    if (existing) {
+      throw new Error("Email already subscribed");
+    }
+
+    const subscriber = new NewsletterSubscriber(data);
+    return subscriber.save();
+  }
+}
+
+export default NewsletterService;

--- a/src/tests/newsletter.test.ts
+++ b/src/tests/newsletter.test.ts
@@ -1,0 +1,36 @@
+import request from "supertest";
+import app from "../app";
+import NewsletterSubscriber from "../models/newsletter.model";
+
+describe("Newsletter Subscription API", () => {
+  beforeAll(async () => {
+    await NewsletterSubscriber.deleteMany({});
+  });
+
+  it("should subscribe a new email", async () => {
+    const res = await request(app)
+      .post("/api/newsletter/subscribe")
+      .send({ email: "test@example.com", source: "footer-form" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.subscriber.email).toBe("test@example.com");
+  });
+
+  it("should reject duplicate email", async () => {
+    await request(app)
+      .post("/api/newsletter/subscribe")
+      .send({ email: "dup@example.com" });
+    const res = await request(app)
+      .post("/api/newsletter/subscribe")
+      .send({ email: "dup@example.com" });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("should reject invalid email", async () => {
+    const res = await request(app)
+      .post("/api/newsletter/subscribe")
+      .send({ email: "invalid-email" });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
This adds a new API endpoint. Users can now subscribe to the newsletter without being on the waitlist. It features validation, handles duplicate emails, logs metadata, and includes unit tests.

Implemented NewsletterService.subscribe() to manage subscription logic.

Created the POST /api/newsletter/subscribe endpoint in newsletter.controller.ts.

Added validation middleware for email, which is required and must be valid, and for source, which is optional and can be up to 100 characters.

Logs subscriber metadata, including IP address and user-agent.

Added unit tests that cover