### PR TITLE
feat: enhance waitlist email template with dark mode support

### DIFF
--- a/waitlist-email-template.html
+++ b/waitlist-email-template.html
@@ -99,11 +99,50 @@
           background-color: #ffffff !important;
           color: #000000 !important;
         }
+        .dark-mode-logo {
+          content: url('https://staging.boundlessfi.xyz/boundless.png') !important;
+        }
+      }
+      
+      /* Dark mode class-based support for email clients that support it */
+      .dark-mode {
+        background-color: #1a1a1a !important;
+      }
+      .dark-mode .email-wrapper {
+        background-color: #1a1a1a !important;
+      }
+      .dark-mode .header-bg {
+        background-color: #1a1a1a !important;
+      }
+      .dark-mode .hero-bg {
+        background-color: #1a1a1a !important;
+      }
+      .dark-mode .disclaimer-bg {
+        background-color: #1a1a1a !important;
+      }
+      .dark-mode .footer-bg {
+        background-color: #1a1a1a !important;
+      }
+      .dark-mode .main-text {
+        color: #ffffff !important;
+      }
+      .dark-mode .secondary-text {
+        color: #cccccc !important;
+      }
+      .dark-mode .button-bg {
+        background-color: #ffffff !important;
+      }
+      .dark-mode .button-text {
+        color: #000000 !important;
+      }
+      .dark-mode .logo-img {
+        content: url('https://staging.boundlessfi.xyz/boundless.png') !important;
       }
     </style>
   </head>
 
   <body
+    class="dark-mode-bg"
     style="
       margin: 0;
       padding: 0;
@@ -138,6 +177,7 @@
       cellspacing="0"
       border="0"
       width="100%"
+      class="dark-mode-bg"
       style="background-color: #f5f5f0"
     >
       <tr>
@@ -149,6 +189,7 @@
             cellspacing="0"
             border="0"
             width="600"
+            class="email-wrapper dark-mode-bg"
             style="
               max-width: 600px;
               background-color: #f5f5f0;
@@ -159,6 +200,7 @@
             <!-- Header -->
             <tr>
               <td
+                class="header-bg dark-mode-bg"
                 style="padding: 30px 40px 20px 40px; background-color: #f5f5f0"
               >
                 <table
@@ -171,97 +213,7 @@
                   <tr>
                     <td align="left" style="vertical-align: middle">
                       <!-- Company Logo -->
-                      <svg
-                        width="168"
-                        height="27"
-                        viewBox="0 0 168 27"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M6.9972 25.1895L20.9916 16.7936V9.79644L6.9972 0L0 4.19794L13.9944 12.5938L6.9972 16.7936V25.1895Z"
-                          fill="url(#paint0_linear_3240_47905)"
-                        />
-                        <path
-                          d="M22.2229 1.69385L36.2173 10.0897V17.0869L22.2229 26.8834L15.2257 22.6854L29.2201 14.2895L22.2229 10.0897V1.69385Z"
-                          fill="url(#paint1_linear_3240_47905)"
-                        />
-                        <path
-                          d="M40.2173 23.4015V3.69765H48.0981C51.8204 3.69765 54.1966 5.88779 54.1966 8.76412C54.1966 10.5783 53.6966 11.7984 52.6024 12.5485C54.5407 13.4245 55.4806 14.9887 55.4806 17.239C55.4806 21.1794 52.6663 23.3996 47.9439 23.3996H40.2192L40.2173 23.4015ZM43.9697 7.13796V11.1723H47.692C49.5061 11.1723 50.2882 10.3903 50.2882 9.14012C50.2882 7.82603 49.6001 7.13796 47.66 7.13796H43.9697ZM43.9697 14.6127V19.9612H47.786C50.4762 19.9612 51.5703 18.961 51.5703 17.2408C51.5703 15.5207 50.4123 14.6145 47.786 14.6145H43.9697V14.6127Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M64.0476 7.92009C68.364 7.92009 71.9284 11.2044 71.9284 15.8009C71.9284 20.3974 68.3621 23.6516 64.0476 23.6516C59.7331 23.6516 56.1349 20.3673 56.1349 15.8009C56.1349 11.2344 59.6692 7.92009 64.0476 7.92009ZM64.0476 19.9932C66.2998 19.9932 68.176 18.367 68.176 15.7708C68.176 13.1746 66.2998 11.5804 64.0476 11.5804C61.7954 11.5804 59.8572 13.2065 59.8572 15.7708C59.8572 18.335 61.7334 19.9932 64.0476 19.9932Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M72.5863 8.07623H76.3086V16.333C76.3086 18.9292 77.4347 20.0553 79.4989 20.0553C82.1572 20.0553 83.6893 17.773 83.6893 17.773V8.07811H87.4417V23.4035H84.1574L83.7514 21.3713C82.4692 22.8414 80.781 23.6554 78.7169 23.6554C75.1506 23.6554 72.5863 20.9351 72.5863 17.2429V8.07623Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M103.079 23.4016H99.3569V15.2689C99.3569 12.6426 98.2308 11.5165 96.1666 11.5165C93.5084 11.5165 91.9762 13.7067 91.9762 13.7067V23.4016H88.2238V8.0762H91.6641L91.9762 10.1084C93.2264 8.67026 94.9165 7.91828 96.9487 7.91828C100.515 7.91828 103.079 10.6386 103.079 14.3308V23.4016Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M115.995 3.22778H119.747V23.4016H116.307L116.025 21.6495C114.742 22.9636 113.022 23.6517 111.24 23.6517C107.05 23.6517 103.733 20.3674 103.733 15.8009C103.733 11.2345 107.048 7.92015 111.24 7.92015C113.022 7.92015 114.712 8.60821 115.995 9.89034V3.22778ZM111.648 11.5165C109.302 11.5165 107.394 13.1746 107.394 15.8009C107.394 18.4272 109.302 20.0553 111.648 20.0553C113.994 20.0553 115.995 18.3971 115.995 15.8009C115.995 13.2047 114.056 11.5165 111.648 11.5165Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M120.529 3.22778H124.281V23.4016H120.529V3.22778Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M140.483 17.897C139.951 21.3374 136.448 23.6516 132.82 23.6516C128.442 23.6516 124.907 20.3673 124.907 15.8009C124.907 11.2344 128.442 7.92009 132.82 7.92009C137.199 7.92009 140.483 10.7663 140.609 15.2707V16.7089H128.724C129.1 18.7411 130.788 19.9932 132.82 19.9932C134.384 19.9932 135.822 19.2431 136.479 17.897H140.483ZM136.322 13.7367C135.696 12.3925 134.414 11.5785 132.82 11.5785C131.226 11.5785 129.786 12.3925 129.098 13.7367H136.322Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M153.462 19.1473C153.462 21.8675 151.272 23.6516 147.676 23.6516C143.891 23.6516 141.357 21.1494 141.265 18.0212H145.017C145.173 19.2713 146.267 19.9914 147.738 19.9914C148.896 19.9914 149.708 19.6154 149.708 18.9273C149.708 17.2391 141.483 18.4893 141.483 12.7028C141.483 10.0765 143.829 7.91828 147.425 7.91828C151.022 7.91828 153.212 10.2024 153.306 13.5788H149.522C149.304 12.2647 148.522 11.5767 147.301 11.5767C146.081 11.5767 145.205 12.0147 145.205 12.7968C145.205 15.0489 153.462 13.6728 153.462 19.1454V19.1473Z"
-                          fill="#0E0F0C"
-                        />
-                        <path
-                          d="M166.159 19.1473C166.159 21.8675 163.969 23.6516 160.373 23.6516C156.588 23.6516 154.054 21.1494 153.962 18.0212H157.714C157.87 19.2713 158.965 19.9914 160.435 19.9914C161.593 19.9914 162.405 19.6154 162.405 18.9273C162.405 17.2391 154.18 18.4893 154.18 12.7028C154.18 10.0765 156.526 7.91828 160.123 7.91828C163.719 7.91828 165.909 10.2024 166.003 13.5788H162.219C162.001 12.2647 161.219 11.5767 159.999 11.5767C158.779 11.5767 157.902 12.0147 157.902 12.7968C157.902 15.0489 166.159 13.6728 166.159 19.1454V19.1473Z"
-                          fill="#0E0F0C"
-                        />
-                        <defs>
-                          <linearGradient
-                            id="paint0_linear_3240_47905"
-                            x1="16.9609"
-                            y1="51.3189"
-                            x2="3.93225"
-                            y2="50.8234"
-                            gradientUnits="userSpaceOnUse"
-                          >
-                            <stop stop-color="#A7F950" stop-opacity="0.5" />
-                            <stop offset="1" stop-color="#3AE6B2" />
-                          </linearGradient>
-                          <linearGradient
-                            id="paint1_linear_3240_47905"
-                            x1="32.1866"
-                            y1="53.0128"
-                            x2="19.158"
-                            y2="52.5173"
-                            gradientUnits="userSpaceOnUse"
-                          >
-                            <stop stop-color="#A7F950" stop-opacity="0.5" />
-                            <stop offset="1" stop-color="#3AE6B2" />
-                          </linearGradient>
-                        </defs>
-                      </svg>
-                    </td>
-                    <td align="right" style="vertical-align: middle">
-                      <a
-                        href="{{viewInBrowserUrl}}"
-                        style="
-                          color: #666666;
-                          text-decoration: none;
-                          font-size: 12px;
-                          font-family:
-                            -apple-system, BlinkMacSystemFont,
-                            &quot;Segoe UI&quot;, Roboto, Helvetica, Arial,
-                            sans-serif;
-                        "
-                        >View in browser</a
-                      >
+                       <img src="https://staging.boundlessfi.xyz/boundless-light.png" alt="Boundless Logo" width="168" height="27" class="logo-img dark-mode-logo" />
                     </td>
                   </tr>
                 </table>
@@ -270,7 +222,7 @@
 
             <!-- Hero Section -->
             <tr>
-              <td style="padding: 0 40px 30px 40px; background-color: #f5f5f0">
+              <td class="hero-bg dark-mode-bg" style="padding: 0 40px 30px 40px; background-color: #f5f5f0">
                 <table
                   role="presentation"
                   cellpadding="0"
@@ -281,6 +233,7 @@
                   <tr>
                     <td align="center" style="padding-bottom: 20px">
                       <h1
+                        class="main-text dark-mode-text"
                         style="
                           margin: 0;
                           font-size: 32px;
@@ -301,6 +254,7 @@
                   <tr>
                     <td align="center" style="padding-bottom: 30px">
                       <p
+                        class="secondary-text dark-mode-text"
                         style="
                           margin: 0;
                           font-size: 16px;
@@ -321,6 +275,7 @@
                   <tr>
                     <td align="center" style="padding-bottom: 30px">
                       <p
+                        class="secondary-text dark-mode-text"
                         style="
                           margin: 0;
                           font-size: 16px;
@@ -352,6 +307,7 @@
                         <tr>
                           <td
                             align="left"
+                            class="button-bg dark-mode-button"
                             style="
                               background-color: #000000;
                               border-radius: 6px;
@@ -362,6 +318,7 @@
                               href="{{ctaUrl}}"
                               role="link"
                               aria-label="See announcement for Boundless"
+                              class="button-text dark-mode-button"
                               style="
                                 display: inline-block;
                                 padding: 16px 32px;
@@ -390,8 +347,9 @@
 
             <!-- Disclaimer Section -->
             <tr>
-              <td style="padding: 0 40px 40px 40px; background-color: #f5f5f0">
+              <td class="disclaimer-bg dark-mode-bg" style="padding: 0 40px 40px 40px; background-color: #f5f5f0">
                 <p
+                  class="secondary-text dark-mode-text"
                   style="
                     margin: 0;
                     font-size: 14px;
@@ -412,7 +370,7 @@
 
             <!-- Footer -->
             <tr>
-              <td style="padding: 20px 40px; background-color: #f5f5f0">
+              <td class="footer-bg dark-mode-bg" style="padding: 20px 40px; background-color: #f5f5f0">
                 <table
                   role="presentation"
                   cellpadding="0"
@@ -510,6 +468,7 @@
                   <tr>
                     <td align="left" style="padding-bottom: 15px">
                       <p
+                        class="secondary-text dark-mode-text"
                         style="
                           margin: 0;
                           font-size: 12px;
@@ -529,6 +488,7 @@
                   <tr>
                     <td align="left">
                       <p
+                        class="secondary-text dark-mode-text"
                         style="
                           margin: 0;
                           font-size: 12px;


### PR DESCRIPTION
- Added dark mode styles to the waitlist email template for improved readability in dark-themed email clients.
- Replaced the SVG logo with an image tag for better compatibility across email clients.
- Updated various sections of the template to support dark mode background and text colors.